### PR TITLE
employee-info-mgt-app: EDIT FUNCTION: SAVE button in edit function is…

### DIFF
--- a/src/main/java/com/employee/info/mgt/app/controllers/item/ChangePswController.java
+++ b/src/main/java/com/employee/info/mgt/app/controllers/item/ChangePswController.java
@@ -41,6 +41,16 @@ public class ChangePswController {
     private UserFacade userFacade = new UserFacadeImpl();
 
     @FXML
+    private void initialize() {
+        saveChangePswButton.disableProperty().bind(
+                usernameField.textProperty().isEmpty()
+                        .or(currentPswField.textProperty().isEmpty())
+                        .or(newPswField.textProperty().isEmpty())
+                        .or(confirmPswField.textProperty().isEmpty())
+        );
+    }
+
+    @FXML
     protected void onSaveChangePswClicked(ActionEvent event) {
         User updatePsw = new User();
         String newPassword = newPswField.getText();


### PR DESCRIPTION
Description

Defect description: I can click the SAVE button even if there is no fill-up information.

Expected result: SAVE button should be disabled when there is no fill-up information and it should throw an error: "all fields are important. Please enter valid input"

Actual result: SAVE button is not disabled and it doesn't throw and error: "all fields are important. Please enter valid input" 